### PR TITLE
Allow to use different views.

### DIFF
--- a/includes/webform_workflow.pages.inc
+++ b/includes/webform_workflow.pages.inc
@@ -15,12 +15,14 @@ function webform_workflow_submissions_list($node) {
     module_load_include('inc', 'webform', 'includes/webform.report');
     return webform_results_submissions($node, FALSE, 50);
   }
-  $view = views_get_view('webform_workflow_submissions');
+  $view = views_get_view('webform_workflow_submissions_'.$node->nid);
+  if (empty($view) || $view->disabled) {
+    $view = views_get_view('webform_workflow_submissions');
+  }
   $view->override_path = current_path();
   $view->override_url = current_path();
   return $view->preview('embed', array($node->nid));
 }
-
 /**
  * Page callback to display a workflow transition log for a submission.
  */


### PR DESCRIPTION
If cloning the view webform_worflow_submission and naming the new one
like  webform_workflow_submissions_999 (Where 999 is a webform nid) then
this clone will be used when the webform is the 999 and webform_workflow is activate.

It's the same behavior with views - webforms without workflow